### PR TITLE
Ability to resolve a service provider

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       CC_TEST_REPORTER_ID: ${{ secrets.github_token }}
     strategy:
       matrix:
-        php-versions: ['7.1', '7.2', '7.3', '7.4']
+        php-versions: ['7.2', '7.3', '7.4']
 
     steps:
     - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         }
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "psr/container": "^1.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0a8724232e324e8c0000895b1ecbcb84",
+    "content-hash": "1a9162f73ec1a3834aab907a6afa06fa",
     "packages": [
         {
             "name": "psr/container",
@@ -169,7 +169,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1"
+        "php": "^7.2"
     },
     "platform-dev": [],
     "plugin-api-version": "1.1.0"

--- a/src/Container/Resolver.php
+++ b/src/Container/Resolver.php
@@ -34,6 +34,8 @@ class Resolver
     {
         if (is_string($instance) && false !== strpos($instance, '::')) {
             $instance = explode('::', $instance);
+        } elseif (is_object($instance)) {
+            $instance = (new \ReflectionMethod($instance, '__invoke'))->getClosure($instance);
         }
 
         $params = [];

--- a/src/Container/Resolver.php
+++ b/src/Container/Resolver.php
@@ -66,11 +66,7 @@ class Resolver
             return $this->createInstance($concrete);
         }
 
-        if ($concrete instanceof \Closure) {
-            return $concrete->bindTo($this->container);
-        }
-
-        if (is_object($concrete) || is_callable($concrete)) {
+        if ($concrete instanceof \Closure || is_object($concrete) || is_callable($concrete)) {
             return $concrete;
         }
 

--- a/test/spec/Container.spec.php
+++ b/test/spec/Container.spec.php
@@ -3,7 +3,7 @@
 use Projek\Container;
 use Projek\Container\{ArrayContainer, ContainerInterface, Exception, NotFoundException, Resolver };
 use Psr\Container\ContainerInterface as PsrContainer;
-use Stubs\ { Dummy, AbstractFoo, ConcreteBar };
+use Stubs\ { Dummy, AbstractFoo, ConcreteBar, ServiceProvider};
 use function Kahlan\describe;
 use function Kahlan\expect;
 
@@ -26,6 +26,15 @@ describe(Container::class, function () {
 
     it('Should register it-self', function () {
         expect($this->c->get(PsrContainer::class))->toBeAnInstanceOf(PsrContainer::class);
+    });
+
+    it('Should resolve serive provider', function () {
+        $this->c->set('dummy', Dummy::class);
+        $this->c->set(AbstractFoo::class, ConcreteBar::class);
+
+        $this->c->set('myService', ServiceProvider::class);
+
+        expect($this->c->get('myService'))->toEqual('dummy lorem');
     });
 
     it('Should manage instance', function () {

--- a/test/spec/Resolver.spec.php
+++ b/test/spec/Resolver.spec.php
@@ -26,7 +26,7 @@ describe(Resolver::class, function () {
     it('could handle array callable', function () {
         expect(
             $this->r->handle([$this->dummy, 'lorem'])
-        )->toEqual('lorem');
+        )->toEqual('dummy lorem');
 
         expect(
             $this->r->handle([ConcreteBar::class, 'std'])

--- a/test/stub/AbstractFoo.php
+++ b/test/stub/AbstractFoo.php
@@ -4,7 +4,7 @@ namespace Stubs;
 
 abstract class AbstractFoo
 {
-    public function lorem($text = 'lorem')
+    public function lorem(string $text = 'lorem')
     {
         return $text;
     }

--- a/test/stub/Dummy.php
+++ b/test/stub/Dummy.php
@@ -4,9 +4,9 @@ namespace Stubs;
 
 class Dummy
 {
-    public function lorem(AbstractFoo $foo)
+    public function lorem(AbstractFoo $foo, $text = 'dummy lorem')
     {
-        return $foo->lorem();
+        return $foo->lorem($text);
     }
 }
 

--- a/test/stub/ServiceProvider.php
+++ b/test/stub/ServiceProvider.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Stubs;
+
+class ServiceProvider
+{
+    protected $abs;
+
+    public function __construct(AbstractFoo $abs)
+    {
+        $this->abs = $abs;
+    }
+
+    /**
+     * @param Dummy $d
+     * @return string
+     */
+    public function __invoke($dummy)
+    {
+        return $dummy->lorem($this->abs);
+    }
+}


### PR DESCRIPTION
Sample service provider

https://github.com/projek-xyz/container/blob/b47b01d8edf60d3d0eb5bacf14c484461f6df141/test/stub/ServiceProvider.php#L5-L22

Its depends on 2 services `dummy` and `AbstractFoo` which is resolved by registering the services as following;

```php
$container->set('dummy', $dummyInstance);
$container->set(AbstractFoo::class, $abstractInstance);
```

The `AbstractFoo` instance will be injected when registering the service

```php
$container->set('myService', ServiceProvider::class);
```

While the `dummy` instance will be injected when retrieving the service

```php
$container->get('myService');
```

So the `myService` instance will have the return value of `ServiceProvider::__invoke()` method instead of instance of `ServiceProvider` class.