### PR TITLE
Disable similar-code check

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,6 +1,8 @@
 version: "2"
 
 checks:
+  similar-code:
+    enabled: false
   method-complexity:
     config:
       threshold: 9
@@ -16,6 +18,3 @@ engines:
 ratings:
   paths:
     - src/**.php
-
-exclude_paths:
-  - test/**/*


### PR DESCRIPTION
It's annoying when similar-code detect docblock as acode

![image](https://user-images.githubusercontent.com/508665/84513874-4ce07e80-acf4-11ea-9585-af4790d8aea7.png)
