### PR TITLE
Mark it-self as a container

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -32,8 +32,9 @@ class Container implements ContainerInterface
     {
         $this->resolver = new Resolver($this);
 
-        $this->set(ContainerInterface::class, $this);
-        $this->set(PsrContainerInterface::class, ContainerInterface::class);
+        $this->set(self::class, $this);
+        $this->set(ContainerInterface::class, self::class);
+        $this->set(PsrContainerInterface::class, self::class);
 
         foreach ($instances as $id => $instance) {
             $this->set($id, $instance);

--- a/test/spec/Container.spec.php
+++ b/test/spec/Container.spec.php
@@ -1,7 +1,7 @@
 <?php
 
 use Projek\Container;
-use Projek\Container\{ArrayContainer, ContainerInterface, Exception, NotFoundException, Resolver };
+use Projek\Container\{ContainerInterface, Exception, NotFoundException };
 use Psr\Container\ContainerInterface as PsrContainer;
 use Stubs\ { Dummy, AbstractFoo, ConcreteBar, ServiceProvider};
 use function Kahlan\describe;

--- a/test/spec/Container.spec.php
+++ b/test/spec/Container.spec.php
@@ -19,13 +19,17 @@ describe(Container::class, function () {
             }
         ]);
 
-        expect($m)->toBeAnInstanceOf(ContainerInterface::class);
-        expect($m)->toBeAnInstanceOf(PsrContainer::class);
         expect($m->get(stdClass::class))->toBeAnInstanceOf(stdClass::class);
     });
 
     it('Should register it-self', function () {
-        expect($this->c->get(PsrContainer::class))->toBeAnInstanceOf(PsrContainer::class);
+        $self = [Container::class, PsrContainer::class, ContainerInterface::class];
+
+        foreach ($self as $a) {
+            foreach ($self as $b) {
+                expect($this->c->get($a))->toBeAnInstanceOf($b);
+            }
+        }
     });
 
     it('Should resolve serive provider', function () {


### PR DESCRIPTION
Add possibilities to use the container like these

```php
$container->set('foo', function (\Psr\Container\ContainerInterface $container) {
    return new Foo($container);
});

// OR
$container->set('foo', function (\Projek\Container\ContainerInterface $container) {
    return new Foo($container);
});

// OR
$container->set('foo', function (\Projek\Container $container) {
    return new Foo($container);
});
```