### PR TITLE
Add make() method

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -96,14 +96,14 @@ class Container implements ContainerInterface
     /**
      * {@inheritDoc}
      */
-    public function make(string $concrete)
+    public function make(string $concrete, ?\Closure $condition = null)
     {
         $instance = $this->resolver->resolve($concrete);
 
-        if (is_callable($instance)) {
-            return $this->resolver->handle($instance);
+        if (null !== $condition) {
+            $instance = $condition($instance) ?? $instance;
         }
 
-        return $instance;
+        return $this->resolver->handle($instance);
     }
 }

--- a/src/Container.php
+++ b/src/Container.php
@@ -92,4 +92,18 @@ class Container implements ContainerInterface
     {
         unset($this->instances[$id]);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function make(string $concrete)
+    {
+        $instance = $this->resolver->resolve($concrete);
+
+        if (is_callable($instance)) {
+            return $this->resolver->handle($instance);
+        }
+
+        return $instance;
+    }
 }

--- a/src/Container/ContainerInterface.php
+++ b/src/Container/ContainerInterface.php
@@ -24,4 +24,12 @@ interface ContainerInterface extends PsrContainerInterface
      * @return void
      */
     public function unset(string $id): void;
+
+    /**
+     * Resolve an instance without adding it to the stack.
+     *
+     * @param string $concrete
+     * @return mixed
+     */
+    public function make(string $concrete);
 }

--- a/src/Container/ContainerInterface.php
+++ b/src/Container/ContainerInterface.php
@@ -29,7 +29,8 @@ interface ContainerInterface extends PsrContainerInterface
      * Resolve an instance without adding it to the stack.
      *
      * @param string $concrete
+     * @param null|\Closure $condition
      * @return mixed
      */
-    public function make(string $concrete);
+    public function make(string $concrete, ?\Closure $condition = null);
 }

--- a/src/Container/Resolver.php
+++ b/src/Container/Resolver.php
@@ -47,7 +47,7 @@ class Resolver
             : new \ReflectionFunction($instance);
 
         if ($isMethod) {
-            $params[] = $instance[0];
+            $params[] = is_object($instance[0]) ? $instance[0] : null;
         }
 
         // If it was internal method resolve its params as a closure.

--- a/src/Container/Resolver.php
+++ b/src/Container/Resolver.php
@@ -33,24 +33,21 @@ class Resolver
      * @param array $args
      * @return mixed
      */
-    public function handle(callable $instance, array $args = [])
+    public function handle($instance, array $args = [])
     {
-        $isInternalMethod = false;
-
-        if (is_string($instance) && false !== strpos($instance, '::')) {
-            $instance = explode('::', $instance);
-        } elseif (is_object($instance) && method_exists($instance, '__invoke')) {
-            $isInternalMethod = true;
-            $instance = [$instance, '__invoke'];
+        if (! $this->assertCallable($instance)) {
+            return $instance;
         }
 
         $params = [];
-        $reflector = ($isMethod = is_array($instance))
+        $isMethod = is_array($instance);
+        $isInternalMethod = $isMethod && $instance[1] === '__invoke';
+        $reflector = $isMethod
             ? new \ReflectionMethod($instance[0], $instance[1])
             : new \ReflectionFunction($instance);
 
         if ($isMethod) {
-            $params[] = is_object($instance[0]) ? $instance[0] : null;
+            $params[] = $instance[0];
         }
 
         // If it was internal method resolve its params as a closure.
@@ -144,5 +141,30 @@ class Resolver
         }
 
         return $args;
+    }
+
+    /**
+     * Assert $instance is callable.
+     *
+     * @param callable $instance
+     * @return bool
+     * @throws \BadMethodCallException When $instance is an array but the callable
+     *                                 method not exists.
+     */
+    private function assertCallable(&$instance): bool
+    {
+        if (is_string($instance) && false !== strpos($instance, '::')) {
+            $instance = explode('::', $instance);
+        } elseif (is_object($instance) && method_exists($instance, '__invoke')) {
+            $instance = [$instance, '__invoke'];
+        }
+
+        if (is_array($instance) && ! method_exists($instance[0], $instance[1])) {
+            throw new \BadMethodCallException(
+                sprintf('Call to undefined method %s::%s()', get_class($instance[0]), $instance[1])
+            );
+        }
+
+        return is_callable($instance);
     }
 }

--- a/test/spec/Container.spec.php
+++ b/test/spec/Container.spec.php
@@ -3,7 +3,7 @@
 use Projek\Container;
 use Projek\Container\{ContainerInterface, Exception, NotFoundException };
 use Psr\Container\ContainerInterface as PsrContainer;
-use Stubs\ { Dummy, AbstractFoo, ConcreteBar, ServiceProvider};
+use Stubs\{Dummy, AbstractFoo, ConcreteBar, ServiceProvider};
 use function Kahlan\describe;
 use function Kahlan\expect;
 
@@ -103,6 +103,10 @@ describe(Container::class, function () {
 
     it('Should throw exception when setting incorrect param', function () {
         expect(function () {
+            $this->c->make(AbstractFoo::class);
+        })->toThrow(Exception::notInstantiable(AbstractFoo::class));
+
+        expect(function () {
             $this->c->set('foo', AbstractFoo::class);
         })->toThrow(Exception::notInstantiable(AbstractFoo::class));
 
@@ -117,5 +121,22 @@ describe(Container::class, function () {
         expect(function () {
             $this->c->set('foo', null);
         })->toThrow(Exception::unresolvable('NULL'));
+    });
+
+    it('Should make an instance without adding to the stack', function () {
+        // Dependencies.
+        $this->c->set('dummy', Dummy::class);
+        $this->c->set(AbstractFoo::class, ConcreteBar::class);
+
+        $instances = [
+            Stubs\CallableClass::class => AbstractFoo::class,
+            Stubs\InstantiableClass::class => Stubs\InstantiableClass::class,
+        ];
+
+        foreach ($instances as $concrete => $instance) {
+            expect($this->c->has($concrete))->toBeFalsy();
+            expect($this->c->make($concrete))->toBeAnInstanceOf($instance);
+            expect($this->c->has($concrete))->toBeFalsy();
+        }
     });
 });

--- a/test/stub/CallableClass.php
+++ b/test/stub/CallableClass.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Stubs;
+
+class CallableClass
+{
+    /**
+     * @var stdClass
+     */
+    public $dummy;
+
+    public function __construct($dummy)
+    {
+        $this->dummy = $dummy;
+    }
+
+    public function __invoke(AbstractFoo $foo)
+    {
+        return $foo;
+    }
+}

--- a/test/stub/CertainInterface.php
+++ b/test/stub/CertainInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Stubs;
+
+interface CertainInterface
+{
+    public function handle(AbstractFoo $dummy): string;
+}

--- a/test/stub/InstantiableClass.php
+++ b/test/stub/InstantiableClass.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Stubs;
+
+class InstantiableClass
+{
+    /**
+     * @var stdClass
+     */
+    public $dummy;
+
+    public function __construct($dummy)
+    {
+        $this->dummy = $dummy;
+    }
+}

--- a/test/stub/SomeClass.php
+++ b/test/stub/SomeClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Stubs;
+
+class SomeClass implements CertainInterface
+{
+    public function handle(AbstractFoo $dummy): string
+    {
+        return $dummy->lorem();
+    }
+}


### PR DESCRIPTION
Ability to resolve an instance without adding it to the container stack.

Let say you have a class like this

https://github.com/projek-xyz/container/blob/c0bc43a0ad9d6520f0eeca2da0d8ea790aad9fad/test/stub/InstantiableClass.php#L5-L16

```php
$container->make(InstantiablleClass::class); // Should get InstantiablleClass instance.
```

If you have callable class like this

https://github.com/projek-xyz/container/blob/c0bc43a0ad9d6520f0eeca2da0d8ea790aad9fad/test/stub/CallableClass.php#L5-L21

```php
$container->make(CallableClass::class); // Should get returns value o CallableClass::__invoke().
```

Note that both `InstantiableClass` and `CallableClass` constructor depends on `dummy` container and `CallableClass::__invoke()` method depends on `AbstractFoo` instance. It will automatically resolved if you already have both `dummy` and `AbstractFoo` container.

```php
$container->set('dummy', Dummy::class);
$container->set(AbstractFoo::class, ConcreteBar::class);
```

Otherwise it will throw `Psr\Container\NotFoundExceptionInterface`

