### PR TITLE
Add optional params to `make()` method

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -117,44 +117,38 @@ class Container implements ContainerInterface
      */
     private function assertParams(array $params = []): array
     {
-        $arguments = [];
-        $condition = null;
+        $error = null;
 
         switch (count($params)) {
             case 0:
                 // do nothing
-                break;
+                return [[], null];
             case 1:
-                $arguments = is_array($params[0]) ? $params[0] : [];
-                $condition = $params[0] instanceof \Closure ? $params[0] : null;
-
                 if (! is_array($params[0]) && ! ($params[0] instanceof \Closure)) {
-                    throw new \InvalidArgumentException(
-                        sprintf('Expect parameter 2 to be an array or Closure, %s given', gettype($params[0]))
-                    );
+                    $error = sprintf('Expect parameter 2 to be an array or Closure, %s given', gettype($params[0]));
+                } else {
+                    $arguments = is_array($params[0]) ? $params[0] : [];
+                    $condition = $params[0] instanceof \Closure ? $params[0] : null;
+
+                    return [$arguments, $condition];
                 }
                 break;
             case 2:
                 if (! is_array($params[0])) {
-                    throw new \InvalidArgumentException(
-                        sprintf('Expect parameter 2 to be an array or Closure, %s given', gettype($params[0]))
-                    );
+                    $error = sprintf('Expect parameter 2 to be an array, %s given', gettype($params[0]));
+                } elseif (! ($params[1] instanceof \Closure) && null !== $params[1]) {
+                    $error = sprintf('Expect parameter 3 to be a Closure, %s given', gettype($params[1]));
+                } else {
+                    return [$params[0], $params[1]];
                 }
-                if (! ($params[1] instanceof \Closure) && null !== $params[1]) {
-                    throw new \InvalidArgumentException(
-                        sprintf('Expect parameter 3 to be a Closure, %s given', gettype($params[0]))
-                    );
-                }
-
-                $arguments = $params[0];
-                $condition = $params[1];
                 break;
             default:
-                throw new \InvalidArgumentException(
-                    sprintf('Could not accept more than 3 arguments, %d given', count($params))
-                );
+                $error = sprintf('Could not accept more than 3 arguments, %d given', count($params) + 1);
+                break;
         }
 
-        return [$arguments, $condition];
+        if ($error) {
+            throw new \InvalidArgumentException($error);
+        }
     }
 }

--- a/src/Container.php
+++ b/src/Container.php
@@ -96,16 +96,16 @@ class Container implements ContainerInterface
     /**
      * {@inheritDoc}
      */
-    public function make(string $concrete, ...$params)
+    public function make($concrete, ...$params)
     {
         $instance = $this->resolver->resolve($concrete);
 
-        list($args, $condition) = count($params)
+        list($args, $condition) = count($params = array_filter($params))
             ? $this->assertParams($params)
             : [[], null];
 
         if (null !== $condition) {
-            $instance = $condition($instance) ?? $instance;
+            $instance = $condition($instance) ?: $instance;
         }
 
         return $this->resolver->handle($instance, $args);

--- a/src/Container.php
+++ b/src/Container.php
@@ -96,14 +96,65 @@ class Container implements ContainerInterface
     /**
      * {@inheritDoc}
      */
-    public function make(string $concrete, ?\Closure $condition = null)
+    public function make(string $concrete, ...$params)
     {
         $instance = $this->resolver->resolve($concrete);
+
+        list($args, $condition) = $this->assertParams($params);
 
         if (null !== $condition) {
             $instance = $condition($instance) ?? $instance;
         }
 
-        return $this->resolver->handle($instance);
+        return $this->resolver->handle($instance, $args);
+    }
+
+    /**
+     * Assert $argumens and $condition by $params
+     *
+     * @param array $params
+     * @return array List of [$argumens, $condition]
+     */
+    private function assertParams(array $params = []): array
+    {
+        $arguments = [];
+        $condition = null;
+
+        switch (count($params)) {
+            case 0:
+                // do nothing
+                break;
+            case 1:
+                $arguments = is_array($params[0]) ? $params[0] : [];
+                $condition = $params[0] instanceof \Closure ? $params[0] : null;
+
+                if (! is_array($params[0]) && ! ($params[0] instanceof \Closure)) {
+                    throw new \InvalidArgumentException(
+                        sprintf('Expect parameter 2 to be an array or Closure, %s given', gettype($params[0]))
+                    );
+                }
+                break;
+            case 2:
+                if (! is_array($params[0])) {
+                    throw new \InvalidArgumentException(
+                        sprintf('Expect parameter 2 to be an array or Closure, %s given', gettype($params[0]))
+                    );
+                }
+                if (! ($params[1] instanceof \Closure) && null !== $params[1]) {
+                    throw new \InvalidArgumentException(
+                        sprintf('Expect parameter 3 to be a Closure, %s given', gettype($params[0]))
+                    );
+                }
+
+                $arguments = $params[0];
+                $condition = $params[1];
+                break;
+            default:
+                throw new \InvalidArgumentException(
+                    sprintf('Could not accept more than 3 arguments, %d given', count($params))
+                );
+        }
+
+        return [$arguments, $condition];
     }
 }

--- a/src/Container/ContainerInterface.php
+++ b/src/Container/ContainerInterface.php
@@ -28,9 +28,27 @@ interface ContainerInterface extends PsrContainerInterface
     /**
      * Resolve an instance without adding it to the stack.
      *
+     * It's possible to add 2nd parameter as an array and it will pass it to
+     * `Resolver::handle($instance, $args)`. While if it was a Closure, it will
+     * treaten as condition.
+     *
+     * ```php
+     * // Treat 2nd parameter as arguments
+     * $container->make(SomeClass::class, ['foo', 'bar'])
+     *
+     * $container->make(SomeClass::class, function ($instance) {
+     *     // a condition
+     * })
+     *
+     * // Treat 2nd parameter as arguments and 3rd as condition
+     * $container->make(SomeClass::class, ['foo', 'bar'], function ($instance) {
+     *     // a condition
+     * })
+     * ```
+     *
      * @param string $concrete
-     * @param null|\Closure $condition
+     * @param null|array|\Closure ...$args
      * @return mixed
      */
-    public function make(string $concrete, ?\Closure $condition = null);
+    public function make(string $concrete, ...$args);
 }

--- a/src/Container/ContainerInterface.php
+++ b/src/Container/ContainerInterface.php
@@ -52,7 +52,7 @@ interface ContainerInterface extends PsrContainerInterface
      * ```
      *
      * @link https://github.com/projek-xyz/container/pull/12
-     * @param string|callable $concrete
+     * @param string|callable $concrete String of class name or callable
      * @param null|array|\Closure ...$args
      * @return mixed
      */

--- a/src/Container/ContainerInterface.php
+++ b/src/Container/ContainerInterface.php
@@ -34,21 +34,27 @@ interface ContainerInterface extends PsrContainerInterface
      *
      * ```php
      * // Treat 2nd parameter as arguments
-     * $container->make(SomeClass::class, ['foo', 'bar'])
+     * $container->make(SomeClass::class, ['a value'])
      *
+     * // Treat 2nd parameter as condition
      * $container->make(SomeClass::class, function ($instance) {
-     *     // a condition
+     *     if ($instance instanceof CertainInterface) {
+     *         return [$instance, 'theMethod'];
+     *     }
+     *
+     *     return null; // Accepts falsy or $instance of the class
      * })
      *
      * // Treat 2nd parameter as arguments and 3rd as condition
-     * $container->make(SomeClass::class, ['foo', 'bar'], function ($instance) {
+     * $container->make(SomeClass::class, ['a value'], function ($instance) {
      *     // a condition
      * })
      * ```
      *
-     * @param string $concrete
+     * @link https://github.com/projek-xyz/container/pull/12
+     * @param string|callable $concrete
      * @param null|array|\Closure ...$args
      * @return mixed
      */
-    public function make(string $concrete, ...$args);
+    public function make($concrete, ...$args);
 }

--- a/src/Container/Resolver.php
+++ b/src/Container/Resolver.php
@@ -47,7 +47,13 @@ class Resolver
             : new \ReflectionFunction($instance);
 
         if ($isMethod) {
-            $params[] = is_object($instance[0]) ? $instance[0] : null;
+            $obj = is_object($instance[0]) ? $instance[0] : null;
+
+            if (! $reflector->isStatic() && is_string($instance[0])) {
+                $obj = $this->createInstance($instance[0]);
+            }
+
+            $params[] = $obj;
         }
 
         // If it was internal method resolve its params as a closure.

--- a/test/spec/Container.spec.php
+++ b/test/spec/Container.spec.php
@@ -184,19 +184,27 @@ describe(Container::class, function () {
 
         expect(function () {
             $this->c->make(Stubs\SomeClass::class, 'string');
-        })->toThrow(new InvalidArgumentException);
+        })->toThrow(new InvalidArgumentException(
+            'Expect parameter 2 to be an array or Closure, string given'
+        ));
 
         expect(function () {
             $this->c->make(Stubs\SomeClass::class, 'string', null);
-        })->toThrow(new InvalidArgumentException);
+        })->toThrow(new InvalidArgumentException(
+            'Expect parameter 2 to be an array, string given'
+        ));
 
         expect(function () {
             $this->c->make(Stubs\SomeClass::class, ['string'], 'condition');
-        })->toThrow(new InvalidArgumentException);
+        })->toThrow(new InvalidArgumentException(
+            'Expect parameter 3 to be a Closure, string given'
+        ));
 
         expect(function () {
             $this->c->make(Stubs\SomeClass::class, ['string'], 'condition', 'more');
-        })->toThrow(new InvalidArgumentException);
+        })->toThrow(new InvalidArgumentException(
+            'Could not accept more than 3 arguments, 4 given'
+        ));
 
         expect(
             $this->c->make(Stubs\SomeClass::class, ['new value'], null)

--- a/test/spec/Container.spec.php
+++ b/test/spec/Container.spec.php
@@ -170,4 +170,42 @@ describe(Container::class, function () {
             });
         })->toThrow(new BadMethodCallException);
     });
+
+    it('Shuold accept 2nd and 3rd params', function () {
+        // Dependencies.
+        $this->c->set('dummy', Dummy::class);
+        $this->c->set(AbstractFoo::class, ConcreteBar::class);
+
+        expect(
+            $this->c->make(Stubs\SomeClass::class, function ($instance) {
+                return [$instance, 'shouldCalled'];
+            })
+        )->toEqual('a value');
+
+        expect(function () {
+            $this->c->make(Stubs\SomeClass::class, 'string');
+        })->toThrow(new InvalidArgumentException);
+
+        expect(function () {
+            $this->c->make(Stubs\SomeClass::class, 'string', null);
+        })->toThrow(new InvalidArgumentException);
+
+        expect(function () {
+            $this->c->make(Stubs\SomeClass::class, ['string'], 'condition');
+        })->toThrow(new InvalidArgumentException);
+
+        expect(function () {
+            $this->c->make(Stubs\SomeClass::class, ['string'], 'condition', 'more');
+        })->toThrow(new InvalidArgumentException);
+
+        expect(
+            $this->c->make(Stubs\SomeClass::class, ['new value'], null)
+        )->toBeAnInstanceOf(Stubs\CertainInterface::class);
+
+        expect(
+            $this->c->make(Stubs\SomeClass::class, ['new value'], function ($instance) {
+                return [$instance, 'shouldCalled'];
+            })
+        )->toEqual('new value');
+    });
 });

--- a/test/spec/Container.spec.php
+++ b/test/spec/Container.spec.php
@@ -229,12 +229,28 @@ describe(Container::class, function () {
         expect(
             // Iggnore falsy param
             $this->c->make(Stubs\SomeClass::class, ['new value'], null)
-            )->toBeAnInstanceOf(Stubs\CertainInterface::class);
+        )->toBeAnInstanceOf(Stubs\CertainInterface::class);
 
-            expect(
-                // Iggnore falsy params
+        expect(
+            // Iggnore falsy params
             $this->c->make(Stubs\SomeClass::class, null, null)
         )->toBeAnInstanceOf(Stubs\CertainInterface::class);
+    });
+
+    it('Should accept closure', function () {
+        expect($this->c->make(function ($param) {
+            return $param;
+        }, ['value']))->toEqual('value');
+
+        expect($this->c->make(function () {
+            return new Stubs\SomeClass;
+        }, ['value'], function ($closure) {
+            $instance = $closure();
+
+            return $instance instanceof Stubs\CertainInterface
+                ? [$instance, 'shouldCalled'] // `shouldCalled` method will get the 'value'
+                : $closure;
+        }))->toEqual('value');
     });
 
     it('Should returns default if condition is falsy', function () {

--- a/test/stub/SomeClass.php
+++ b/test/stub/SomeClass.php
@@ -8,4 +8,9 @@ class SomeClass implements CertainInterface
     {
         return $dummy->lorem();
     }
+
+    public function shouldCalled($param = 'a value')
+    {
+        return $param;
+    }
 }


### PR DESCRIPTION
Add ability to optionally pass additional params to its callback and throws `InvalidArgumentException` if it was invalid, obviously.

**Specs**:
- [x] 2nd param must be an array or closure
  https://github.com/projek-xyz/container/blob/512222ed87779f154304c173f7d3e15cf97e8eef/test/spec/Container.spec.php#L185-L189
  - If it was an array, treat it as arguments for the callback handler
  - If it was a closure, treat it as condition of method should handled by the callback handler
- [x] 3rd param must be a closure, condition of method should handled by the callback handler
  https://github.com/projek-xyz/container/blob/512222ed87779f154304c173f7d3e15cf97e8eef/test/spec/Container.spec.php#L213-L217
- [x] do nothing if no additional params present
- [x] no more than 3 params for `make()`
  https://github.com/projek-xyz/container/blob/512222ed87779f154304c173f7d3e15cf97e8eef/test/spec/Container.spec.php#L203-L207