### PR TITLE
Fix `Container::make()` returns existing instance issue

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -20,6 +20,11 @@ class Container implements ContainerInterface
     private $entries = [];
 
     /**
+     * @var array<string, callable> List of instance's factory to be initiate.
+     */
+    private $factories = [];
+
+    /**
      * @var array<string, mixed> List of instances that been handled.
      */
     private $handledEntries = [];
@@ -110,7 +115,9 @@ class Container implements ContainerInterface
             return $this;
         }
 
-        $this->entries[$id] = $this->resolver->resolve($factory);
+        $this->entries[$id] = $this->resolver->resolve(
+            $this->factories[$id] = $factory
+        );
 
         if (isset($this->handledEntries[$id])) {
             unset($this->handledEntries[$id]);
@@ -165,7 +172,12 @@ class Container implements ContainerInterface
             ));
         }
 
-        $instance = $this->resolver->resolve($instance, $args);
+        $instance = $this->resolver->resolve(
+            \is_string($instance) && isset($this->factories[$instance])
+                ? $this->factories[$instance]
+                : $instance,
+            $args
+        );
 
         if ($callback) {
             $instance = $callback($instance) ?: $instance;

--- a/src/Container.php
+++ b/src/Container.php
@@ -115,9 +115,10 @@ class Container implements ContainerInterface
             return $this;
         }
 
-        $this->entries[$id] = $this->resolver->resolve(
-            $this->factories[$id] = $factory
-        );
+        $this->entries[$id] = $this->resolver->resolve($factory);
+        $this->factories[$id] = \is_object($factory) && ! ($factory instanceof \Closure)
+            ? \get_class($factory)
+            : $factory;
 
         if (isset($this->handledEntries[$id])) {
             unset($this->handledEntries[$id]);

--- a/test/spec/Container.spec.php
+++ b/test/spec/Container.spec.php
@@ -262,21 +262,29 @@ describe(Container::class, function () {
             });
         }
 
-        it('should make an instance using class name', function () {
+        it('should make a new instance using class name', function () {
             expect(
-                $this->c->make(Stubs\SomeClass::class)
+                $one = $this->c->make(Stubs\SomeClass::class)
             )->toBeAnInstanceOf(Stubs\CertainInterface::class);
 
             // Returns class instance because it's not a callable
             expect(
-                $this->c->make(Stubs\SomeClass::class, function () {
+                $two = $this->c->make(Stubs\SomeClass::class, function () {
                     return false;
                 })
             )->toBeAnInstanceOf(Stubs\CertainInterface::class);
+
+            expect($one)->not->toBe($two);
         });
 
-        it('should make a container name', function () {
-            expect($this->c->make('dummy'))->toBeAnInstanceOf(Stubs\Dummy::class);
+        it('should make a new instance of existing container entry', function () {
+            $get = $this->c->get('dummy');
+
+            expect(
+                $make = $this->c->make('dummy')
+            )->toBeAnInstanceOf(Stubs\Dummy::class);
+
+            expect($get)->not->toBe($make);
         });
 
         it('shoud able to make void method', function () {


### PR DESCRIPTION
The `Container::make()` method is intended to (always) create new instance even the `$instance` it-self is already registered in the container entry.

Current behavior is it will check whether the `$instance` is already registered or not, if so it will return it as is.