### PR TITLE
feat: init `EntryCollector`

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -67,7 +67,7 @@ class Container implements ContainerInterface
      */
     public function get(string $id)
     {
-        if (! $this->has($id)) {
+        if (! $this->entries->offsetExists($id)) {
             throw new Container\NotFoundException($id);
         }
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -32,7 +32,7 @@ class Container implements ContainerInterface
     /**
      * @var Container\Resolver Service container resolver.
      */
-    private $resolver;
+    private Container\Resolver $resolver;
 
     /**
      * Create new instance.

--- a/src/Container.php
+++ b/src/Container.php
@@ -81,6 +81,7 @@ class Container implements ContainerInterface
             return $entry;
         }
 
+        /** @var array{object|string,string}|callable|object|string $entry */
         return $this->handledEntries[$id] = $this->resolver->handle($entry);
     }
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -67,10 +67,6 @@ class Container implements ContainerInterface
      */
     public function get(string $id)
     {
-        if (! $this->entries->offsetExists($id)) {
-            throw new Container\NotFoundException($id);
-        }
-
         if (isset($this->handledEntries[$id])) {
             return $this->handledEntries[$id];
         }

--- a/src/Container.php
+++ b/src/Container.php
@@ -59,6 +59,7 @@ class Container implements ContainerInterface
     public function __clone()
     {
         $this->resolver = new Container\Resolver($this);
+        $this->entries = new Container\EntryCollector($this->entries);
     }
 
     /**
@@ -218,16 +219,5 @@ class Container implements ContainerInterface
         }
 
         return $this->entries[$id] = $extended;
-    }
-
-    /**
-     * Determines if the given class is injectable.
-     *
-     * @param object $class
-     * @return ($class is Container\ContainerAware ? true : false)
-     */
-    private function isInjectable(object $class): bool
-    {
-        return $class instanceof Container\ContainerAware && null === $class->getContainer();
     }
 }

--- a/src/Container.php
+++ b/src/Container.php
@@ -15,9 +15,9 @@ use Psr\Container\ContainerInterface;
 class Container implements ContainerInterface
 {
     /**
-     * @var array<string, object|callable> List of instances that been initiated.
+     * @var Container\EntryCollector List of instances that been initiated.
      */
-    private $entries = [];
+    private Container\EntryCollector $entries;
 
     /**
      * @var array<string, Closure|callable> List of instance's factory to be initiate.
@@ -42,10 +42,11 @@ class Container implements ContainerInterface
     public function __construct(array $entries = [])
     {
         $this->resolver = new Container\Resolver($this);
-        $this->entries = [
+
+        $this->entries = new Container\EntryCollector([
             self::class => $this,
             ContainerInterface::class => $this,
-        ];
+        ]);
 
         foreach ($entries as $id => $factory) {
             $this->set($id, $factory);
@@ -92,7 +93,7 @@ class Container implements ContainerInterface
      */
     public function has(string $id): bool
     {
-        return \array_key_exists($id, $this->entries);
+        return $this->entries->offsetExists($id);
     }
 
     /**
@@ -105,7 +106,7 @@ class Container implements ContainerInterface
      */
     public function set(string $id, $factory): static
     {
-        if ($this->has($id)) {
+        if ($this->entries->offsetExists($id)) {
             return $this;
         }
 
@@ -113,13 +114,7 @@ class Container implements ContainerInterface
             ? \get_class($factory)
             : $factory;
 
-        $entry = $this->resolver->resolve($this->factories[$id]);
-
-        if (\is_object($entry) && $this->isInjectable($entry)) {
-            $entry->setContainer($this);
-        }
-
-        $this->entries[$id] = $entry;
+        $this->entries[$id] = $this->resolver->resolve($this->factories[$id]);
 
         if (isset($this->handledEntries[$id])) {
             unset($this->handledEntries[$id]);

--- a/src/Container/ContainerAware.php
+++ b/src/Container/ContainerAware.php
@@ -27,10 +27,11 @@ interface ContainerAware
     /**
      * Retrieve container instance or the instance of registered service.
      *
-     * If no parameter given, this method should returns instance of `Projek\Container`
+     * If no parameter given, this method should returns instance of
+     * `Psr\Container\ContainerInterface`
      *
      * ```php
-     * $instance->getContainer(); // \Projek\Container
+     * $instance->getContainer(); // \Psr\Container\ContainerInterface
      * ```
      *
      * But if a string given, this method should returns instance of registered

--- a/src/Container/EntryCollector.php
+++ b/src/Container/EntryCollector.php
@@ -5,47 +5,53 @@ declare(strict_types=1);
 namespace Projek\Container;
 
 use ArrayAccess;
+use IteratorAggregate;
 use Psr\Container\ContainerInterface;
 
 /**
  * @package Projek\Container
  * @internal
  */
-final class EntryCollector implements ArrayAccess
+final class EntryCollector implements ArrayAccess, IteratorAggregate
 {
     /**
      * @var array<string, object|callable>
      */
     private array $entries = [];
 
-    public function __construct(array $entries = [])
+    public function __construct(iterable $entries = [])
     {
-        foreach ($entries as $offset => $value) {
-            $this->offsetSet($offset, $value);
+        foreach ($entries as $id => $entry) {
+            $this->offsetSet($id, $entry);
         }
     }
 
-    public function offsetExists(mixed $offset): bool
+    public function getIterator(): \Traversable
     {
-        return isset($this->entries[$offset]);
+        return new \ArrayIterator($this->entries);
     }
 
-    public function offsetGet(mixed $offset): mixed
+    public function offsetExists(mixed $id): bool
     {
-        return $this->entries[$offset];
+        return isset($this->entries[$id]);
     }
 
-    public function offsetSet(mixed $offset, mixed $value): void
+    public function offsetGet(mixed $id): mixed
     {
-        if (\is_object($value) && $value instanceof ContainerAware && null === $value->getContainer()) {
-            $value->setContainer($this[ContainerInterface::class]);
+        return $this->entries[$id];
+    }
+
+    public function offsetSet(mixed $id, mixed $entry): void
+    {
+        if ($entry instanceof ContainerAware && null === $entry->getContainer()) {
+            $entry->setContainer($this[ContainerInterface::class]);
         }
 
-        $this->entries[$offset] = $value;
+        $this->entries[$id] = $entry;
     }
 
-    public function offsetUnset(mixed $offset): void
+    public function offsetUnset(mixed $id): void
     {
-        unset($this->entries[$offset]);
+        unset($this->entries[$id]);
     }
 }

--- a/src/Container/EntryCollector.php
+++ b/src/Container/EntryCollector.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Projek\Container;
+
+use ArrayAccess;
+use Psr\Container\ContainerInterface;
+
+/**
+ * @package Projek\Container
+ * @internal
+ */
+final class EntryCollector implements ArrayAccess
+{
+    /**
+     * @var array<string, object|callable>
+     */
+    private array $entries = [];
+
+    public function __construct(array $entries = [])
+    {
+        foreach ($entries as $offset => $value) {
+            $this->offsetSet($offset, $value);
+        }
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return isset($this->entries[$offset]);
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->entries[$offset];
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        if (\is_object($value) && $value instanceof ContainerAware && null === $value->getContainer()) {
+            $value->setContainer($this[ContainerInterface::class]);
+        }
+
+        $this->entries[$offset] = $value;
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->entries[$offset]);
+    }
+}

--- a/src/Container/EntryCollector.php
+++ b/src/Container/EntryCollector.php
@@ -9,16 +9,28 @@ use IteratorAggregate;
 use Psr\Container\ContainerInterface;
 
 /**
+ * Internal storage for container entries.
+ *
+ * This class handles the storage of resolved instances and factories,
+ * ensuring that ContainerAware instances are properly initialized.
+ *
  * @package Projek\Container
  * @internal
+ * @template-implements ArrayAccess<string, object|callable>
+ * @template-implements IteratorAggregate<string, object|callable>
  */
 final class EntryCollector implements ArrayAccess, IteratorAggregate
 {
     /**
-     * @var array<string, object|callable>
+     * @var array<string, object|callable> List of registered entries.
      */
     private array $entries = [];
 
+    /**
+     * Create new instance.
+     *
+     * @param iterable<string, object|callable> $entries
+     */
     public function __construct(iterable $entries = [])
     {
         foreach ($entries as $id => $entry) {
@@ -26,16 +38,32 @@ final class EntryCollector implements ArrayAccess, IteratorAggregate
         }
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @return \Traversable<string, object|callable>
+     */
     public function getIterator(): \Traversable
     {
         return new \ArrayIterator($this->entries);
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @param string $id
+     */
     public function offsetExists(mixed $id): bool
     {
         return isset($this->entries[$id]);
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @param string $id
+     * @return object|callable
+     */
     public function offsetGet(mixed $id): mixed
     {
         $entry = $this->entries[$id];
@@ -47,11 +75,23 @@ final class EntryCollector implements ArrayAccess, IteratorAggregate
         return $entry;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @param string $id
+     * @param object|callable $entry
+     */
     public function offsetSet(mixed $id, mixed $entry): void
     {
         $this->entries[$id] = $entry;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @param string $id
+     * @throws Exception Always, as removing registered entries is not supported.
+     */
     public function offsetUnset(mixed $id): void
     {
         throw new Exception(

--- a/src/Container/EntryCollector.php
+++ b/src/Container/EntryCollector.php
@@ -72,7 +72,11 @@ final class EntryCollector implements ArrayAccess, IteratorAggregate
 
         $entry = $this->entries[$id];
 
-        if ($entry instanceof ContainerAware && null === $entry->getContainer()) {
+        if (
+            $entry instanceof ContainerAware &&
+            $id !== ContainerInterface::class &&
+            null === $entry->getContainer()
+        ) {
             $container = $this->offsetGet(ContainerInterface::class);
 
             if ($container instanceof ContainerInterface) {

--- a/src/Container/EntryCollector.php
+++ b/src/Container/EntryCollector.php
@@ -66,6 +66,10 @@ final class EntryCollector implements ArrayAccess, IteratorAggregate
      */
     public function offsetGet(mixed $id): mixed
     {
+        if (! isset($this->entries[$id])) {
+            throw new NotFoundException($id);
+        }
+
         $entry = $this->entries[$id];
 
         if ($entry instanceof ContainerAware && null === $entry->getContainer()) {

--- a/src/Container/EntryCollector.php
+++ b/src/Container/EntryCollector.php
@@ -54,6 +54,8 @@ final class EntryCollector implements ArrayAccess, IteratorAggregate
 
     public function offsetUnset(mixed $id): void
     {
-        unset($this->entries[$id]);
+        throw new Exception(
+            \sprintf('Removing registered entry "%s" is not supported.', $id)
+        );
     }
 }

--- a/src/Container/EntryCollector.php
+++ b/src/Container/EntryCollector.php
@@ -38,15 +38,17 @@ final class EntryCollector implements ArrayAccess, IteratorAggregate
 
     public function offsetGet(mixed $id): mixed
     {
-        return $this->entries[$id];
-    }
+        $entry = $this->entries[$id];
 
-    public function offsetSet(mixed $id, mixed $entry): void
-    {
         if ($entry instanceof ContainerAware && null === $entry->getContainer()) {
             $entry->setContainer($this[ContainerInterface::class]);
         }
 
+        return $entry;
+    }
+
+    public function offsetSet(mixed $id, mixed $entry): void
+    {
         $this->entries[$id] = $entry;
     }
 

--- a/src/Container/EntryCollector.php
+++ b/src/Container/EntryCollector.php
@@ -69,7 +69,11 @@ final class EntryCollector implements ArrayAccess, IteratorAggregate
         $entry = $this->entries[$id];
 
         if ($entry instanceof ContainerAware && null === $entry->getContainer()) {
-            $entry->setContainer($this[ContainerInterface::class]);
+            $container = $this->offsetGet(ContainerInterface::class);
+
+            if ($container instanceof ContainerInterface) {
+                $entry->setContainer($container);
+            }
         }
 
         return $entry;
@@ -95,7 +99,7 @@ final class EntryCollector implements ArrayAccess, IteratorAggregate
     public function offsetUnset(mixed $id): void
     {
         throw new Exception(
-            \sprintf('Removing registered entry "%s" is not supported.', $id)
+            \sprintf('Removing registered entry "%s" is not supported.', (string) $id)
         );
     }
 }

--- a/src/Container/Resolver.php
+++ b/src/Container/Resolver.php
@@ -40,36 +40,36 @@ final class Resolver
     }
 
     /**
-     * Entry resolver.
+     * Entry factory resolver.
      *
      * Ensure the given argument is a callable.
      *
-     * @param array{class-string<object>,string}|callable|object|string $entry
+     * @param array{class-string<object>,string}|callable|object|string $factory
      * @param array<int, mixed> $args
      * @return callable|object
      * @throws Exception
      * @throws InvalidArgumentException
      */
     public function resolve(
-        array|callable|object|string $entry,
+        array|callable|object|string $factory,
         array $args = []
     ): callable|object {
-        if (\is_string($entry) && ! \function_exists($entry)) {
-            $entry = \str_contains($entry, '::')
-                ? \explode('::', $entry)
-                : $this->createInstance($entry, $args);
+        if (\is_string($factory) && ! \function_exists($factory)) {
+            $factory = \str_contains($factory, '::')
+                ? \explode('::', $factory)
+                : $this->createInstance($factory, $args);
         }
 
-        if (\is_array($entry) && \is_string($entry[0] ?? null)) {
-            $entry[0] = $this->resolve($entry[0], $args);
+        if (\is_array($factory) && \is_string($factory[0] ?? null)) {
+            $factory[0] = $this->resolve($factory[0], $args);
         }
 
-        if (\is_object($entry) || \is_callable($entry)) {
-            return $entry;
+        if (\is_object($factory) || \is_callable($factory)) {
+            return $factory;
         }
 
         throw new InvalidArgumentException(
-            \sprintf('Cannot resolve invalid entry of "%s"', \gettype($entry))
+            \sprintf('Cannot resolve invalid entry of "%s"', \gettype($factory))
         );
     }
 

--- a/tests/spec/EntryCollector.spec.php
+++ b/tests/spec/EntryCollector.spec.php
@@ -2,10 +2,12 @@
 
 declare(strict_types=1);
 
+use Projek\Container;
 use Projek\Container\ContainerAware;
 use Projek\Container\EntryCollector;
 use Projek\Container\Exception;
 use Projek\Container\HasContainer;
+use Projek\Container\NotFoundException;
 use Psr\Container\ContainerInterface;
 
 describe(EntryCollector::class, function () {
@@ -36,8 +38,16 @@ describe(EntryCollector::class, function () {
         expect($result)->toBe($entries);
     });
 
+    it('should throw NotFoundException for missing entries', function () {
+        expect(
+            fn () => $this->collector['not-exists']
+        )->toThrow(
+            new NotFoundException('not-exists')
+        );
+    });
+
     it('should inject container to ContainerAware entries', function () {
-        $container = new Projek\Container();
+        $container = new Container();
         $this->collector[ContainerInterface::class] = $container;
 
         $stub = new class implements ContainerAware {
@@ -52,6 +62,20 @@ describe(EntryCollector::class, function () {
 
         expect($entry)->toBe($stub);
         expect($entry->getContainer())->toBe($container);
+    });
+
+    it('should not recurse infinitely if ContainerInterface itself is ContainerAware', function () {
+        $stub = new class implements ContainerAware {
+            use HasContainer;
+        };
+
+        $this->collector[ContainerInterface::class] = $stub;
+
+        // This should not trigger infinite recursion
+        $entry = $this->collector[ContainerInterface::class];
+
+        expect($entry)->toBe($stub);
+        expect($entry->getContainer())->toBeNull();
     });
 
     it('should not allow entry removal', function () {

--- a/tests/spec/EntryCollector.spec.php
+++ b/tests/spec/EntryCollector.spec.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use Projek\Container\ContainerAware;
+use Projek\Container\EntryCollector;
+use Projek\Container\Exception;
+use Projek\Container\HasContainer;
+use Psr\Container\ContainerInterface;
+
+describe(EntryCollector::class, function () {
+    given('collector', function () {
+        return new EntryCollector();
+    });
+
+    it('should be able to set and get an entry', function () {
+        $this->collector['foo'] = 'bar';
+
+        expect($this->collector['foo'])->toBe('bar');
+        expect(isset($this->collector['foo']))->toBeTruthy();
+    });
+
+    it('should be able to iterate over entries', function () {
+        $entries = [
+            'foo' => 'bar',
+            'baz' => 'qux',
+        ];
+
+        $collector = new EntryCollector($entries);
+        $result = [];
+
+        foreach ($collector as $id => $entry) {
+            $result[$id] = $entry;
+        }
+
+        expect($result)->toBe($entries);
+    });
+
+    it('should inject container to ContainerAware entries', function () {
+        $container = new Projek\Container();
+        $this->collector[ContainerInterface::class] = $container;
+
+        $stub = new class implements ContainerAware {
+            use HasContainer;
+        };
+
+        $this->collector['stub'] = $stub;
+
+        expect($stub->getContainer())->toBeNull();
+
+        $entry = $this->collector['stub'];
+
+        expect($entry)->toBe($stub);
+        expect($entry->getContainer())->toBe($container);
+    });
+
+    it('should not allow entry removal', function () {
+        $this->collector['foo'] = 'bar';
+
+        expect(function () {
+            unset($this->collector['foo']);
+        })->toThrow(
+            new Exception('Removing registered entry "foo" is not supported.')
+        );
+    });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Entry storage moved to a dedicated collector that manages entries, iteration, and injects the container into container-aware entries on retrieval.
* **Behavior Change**
  * Registering an already-existing id is now a no-op; registration no longer injects the container into entries. Retrieval checks presence directly and throws a not-found error when missing. Removing entries is unsupported and errors.
* **Documentation**
  * Clarified container-aware getter return type in docs.
* **Tests**
  * Added specs covering collector behavior, container injection on retrieval, iteration, and error cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projek-xyz/container/pull/82)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->