### PR TITLE
fix: event dispatcher implementation

### DIFF
--- a/.github/wiki/Container-Awareness.md
+++ b/.github/wiki/Container-Awareness.md
@@ -25,11 +25,11 @@ class MyService implements ContainerAware
 }
 ```
 
-## How it works (Event-Driven)
+## How it works (Zero-Config)
 
 As of version 1.x, Container Awareness is powered by the **PSR-14 Event System**. 
 
-When a service is resolved, the container dispatches an `AfterResolution` event. An internal `ListenerProvider` listens for this event and calls `setContainer($this)` on any instance implementing the `ContainerAware` interface.
+Automatic injection works **out-of-the-box** using a minimalist internal event dispatcher. When a service is resolved, the container dispatches an `AfterResolution` event. An internal `ListenerProvider` listens for this event and calls `setContainer($this)` on any instance implementing the `ContainerAware` interface.
 
 ### Using a Custom Dispatcher
 

--- a/.github/wiki/Event-Lifecycle.md
+++ b/.github/wiki/Event-Lifecycle.md
@@ -4,12 +4,13 @@ The Projek Container provides an event lifecycle based on the **PSR-14 Event Dis
 
 ## Architecture
 
-It is important to understand that while this library provides the **Event Classes** and a **`ListenerProvider`**, it does **not** include a full `EventDispatcher` implementation. 
+This library provides the **Event Classes** and a **`ListenerProvider`** for internal features like `ContainerAware` injection. 
 
-The developer is responsible for:
-1.  Providing a PSR-14 compliant `EventDispatcherInterface` implementation (e.g., `symfony/event-dispatcher`).
-2.  Instantiating the dispatcher.
-3.  Passing the dispatcher to the `Container` constructor or via `setEventDispatcher()`.
+While the container includes a minimalist internal `EventDispatcher` to ensure core features work out-of-the-box, it is designed to be used with a full-featured PSR-14 implementation.
+
+The developer can:
+1.  **Use the default**: No configuration needed; `ContainerAware` injection works automatically.
+2.  **Provide a custom dispatcher**: Pass a PSR-14 compliant `EventDispatcherInterface` (e.g., `symfony/event-dispatcher`) to the constructor or via `setEventDispatcher()`.
 
 ## Usage
 
@@ -29,7 +30,7 @@ $container->setEventDispatcher($dispatcher);
 | Event | When | Description |
 | --- | --- | --- |
 | `BeforeRegistration` | Before `Container::set()` | Allows modification of the factory/class before it is registered. |
-| `AfterRegistration` | After `Container::set()` | Dispatched once a service is registered and its entry resolved. |
+| `AfterRegistration` | After `Container::set()` | Dispatched once a service is registered. Allows modification of the entry. |
 | `BeforeResolution` | Before `Container::get()` / `make()` | Allows listeners to modify or redirect the service ID before resolution starts. |
 | `AfterResolution` | After `Container::get()` / `make()` | Dispatched after a service is successfully resolved. |
 
@@ -44,6 +45,23 @@ public function onBeforeRegistration(BeforeRegistration $event): void
     if ($event->id === 'some.service') {
         // Redirect to a different factory
         $event->setFactory(fn() => new AlternativeService());
+    }
+}
+```
+
+### `AfterRegistration`
+
+Dispatched eagerly when a service is set. Useful for eager initialization or global factory wrapping.
+
+```php
+// In a listener:
+public function onAfterRegistration(AfterRegistration $event): void
+{
+    $entry = $event->getEntry();
+    
+    if ($entry instanceof EagerServiceInterface) {
+        // Eagerly initialize a service
+        $entry->initialize();
     }
 }
 ```
@@ -65,7 +83,7 @@ public function onBeforeResolution(BeforeResolution $event): void
 
 ### `AfterResolution`
 
-Dispatched after the instance is created. This is the primary hook for "Setter Injection" or "Inflector" patterns.
+Dispatched after the instance is created. This is the primary hook for "Setter Injection" or the **Decorator Pattern**.
 
 ```php
 // In a listener:
@@ -73,6 +91,12 @@ public function onAfterResolution(AfterResolution $event): void
 {
     $instance = $event->getEntry();
     
+    // Example: Decorator Pattern
+    if ($event->id === 'my.service') {
+        $event->setEntry(new MyServiceDecorator($instance));
+    }
+    
+    // Example: Inflector / Awareness
     if ($instance instanceof LoggerAwareInterface) {
         $instance->setLogger($this->logger);
     }
@@ -81,14 +105,14 @@ public function onAfterResolution(AfterResolution $event): void
 
 ## Performance & Cache Behavior
 
-The `BeforeResolution` and `AfterResolution` events are **only dispatched for non-cached entries**. Once a service is resolved and stored in the container's internal cache, subsequent `get()` calls return the cached instance directly to ensure high performance.
+The `BeforeResolution` and `AfterResolution` events are **only dispatched for non-cached entries**. Once a service is resolved and stored in the container's internal cache, subsequent `get()` calls return the cached instance directly.
 
 - **`ContainerAware`** injection only happens during the very first resolution.
 - Listeners will not be notified on subsequent lookups of the same service.
 
 ## Internal Listener Provider
 
-The library includes `Projek\Container\Events\ListenerProvider` which handles core container features like `ContainerAware` injection. If you provide your own Dispatcher, ensure you register this provider if you wish to maintain auto-injection support.
+The library includes `Projek\Container\Events\ListenerProvider` which handles core container features. If you provide your own Dispatcher, ensure you register this provider to maintain auto-injection support.
 
 ```php
 $provider = new Projek\Container\Events\ListenerProvider();

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ This tiny library aims to provide a dead-simple PSR-11 implementation with flexi
 - **Flexible Registration**: Register services using closures, class names, instances, or even class-method pairs.
 - **Service Extension**: Easily modify or wrap existing services using the `extend()` method.
 - **On-the-fly Resolution**: Create instances without adding them to the container stack using `make()`.
+- **PSR-14 Event Lifecycle**: Fully supports PSR-14 event dispatching for intercepting and filtering container operations.
 - **Container Awareness**: Automatically inject the container into services that implement `ContainerAware`.
-- **Lightweight**: Zero dependencies (other than PSR-11 interface) and a small footprint.
+- **Lightweight**: Minimal dependencies (only PSR-11 and PSR-14 interfaces) and a small footprint.
 
 ## Installation
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -7,7 +7,6 @@ namespace Projek;
 use Closure;
 use Psr\Container\ContainerInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
-use Psr\EventDispatcher\ListenerProviderInterface;
 
 /**
  * PSR-11 Dependency Injection Container implementation.
@@ -89,7 +88,6 @@ class Container implements ContainerInterface
      */
     final public function getEventDispatcher(): EventDispatcherInterface
     {
-        /** @var EventDispatcherInterface $dispatcher */
         $dispatcher = $this->handledEntries[EventDispatcherInterface::class] ?? null;
 
         if ($dispatcher instanceof EventDispatcherInterface) {
@@ -97,29 +95,9 @@ class Container implements ContainerInterface
         }
 
         if (! $this->entries->offsetExists(EventDispatcherInterface::class)) {
-            // Simplest implementation to keep core hooks (like ContainerAware) working.
             $this->entries->offsetSet(
                 EventDispatcherInterface::class,
-                new class ($this) implements EventDispatcherInterface {
-                    private ListenerProviderInterface $provider;
-
-                    public function __construct(ContainerInterface $container)
-                    {
-                        $this->provider = (new Container\Events\ListenerProvider())->setContainer($container);
-                    }
-
-                    public function dispatch(object $event): object
-                    {
-                        /** @var callable[] $listeners */
-                        $listeners = $this->provider->getListenersForEvent($event);
-
-                        foreach ($listeners as $listener) {
-                            $listener($event);
-                        }
-
-                        return $event;
-                    }
-                },
+                new Container\Events\Dispatcher($this)
             );
         }
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -89,8 +89,11 @@ class Container implements ContainerInterface
      */
     final public function getEventDispatcher(): EventDispatcherInterface
     {
-        if (isset($this->handledEntries[EventDispatcherInterface::class])) {
-            return $this->handledEntries[EventDispatcherInterface::class];
+        /** @var EventDispatcherInterface $dispatcher */
+        $dispatcher = $this->handledEntries[EventDispatcherInterface::class] ?? null;
+
+        if ($dispatcher instanceof EventDispatcherInterface) {
+            return $dispatcher;
         }
 
         if (! $this->entries->offsetExists(EventDispatcherInterface::class)) {

--- a/src/Container.php
+++ b/src/Container.php
@@ -130,14 +130,7 @@ class Container implements ContainerInterface
             return $this->handledEntries[$id];
         }
 
-        $entry = $this->entries[$id];
-
-        if (\is_object($entry) && ! \is_callable($entry)) {
-            $resolved = $entry;
-        } else {
-            /** @var array{object|string,string}|callable|object|string $entry */
-            $resolved = $this->resolver->handle($entry);
-        }
+        $resolved = $this->resolver->handle($this->entries[$id]);
 
         if (\is_object($resolved) || \is_callable($resolved)) {
             $this->dispatch($after = new Container\Events\AfterResolution($resolved, $id));
@@ -184,23 +177,23 @@ class Container implements ContainerInterface
             ? \get_class($factory)
             : $factory;
 
-        $this->dispatch($reg = new Container\Events\BeforeRegistration(
+        $this->dispatch($registration = new Container\Events\BeforeRegistration(
             $this->factories[$id],
             $id,
         ));
 
-        $this->entries[$id] = $this->resolver->resolve($reg->getFactory());
+        $this->entries[$id] = $this->resolver->resolve($registration->getFactory());
 
         if (isset($this->handledEntries[$id])) {
             unset($this->handledEntries[$id]);
         }
 
-        $this->dispatch($after = new Container\Events\AfterRegistration(
+        $this->dispatch($registered = new Container\Events\AfterRegistration(
             $this->entries[$id],
             $id,
         ));
 
-        $this->entries[$id] = $after->getEntry();
+        $this->entries[$id] = $registered->getEntry();
 
         return $this;
     }

--- a/src/Container.php
+++ b/src/Container.php
@@ -130,19 +130,21 @@ class Container implements ContainerInterface
             return $this->handledEntries[$id];
         }
 
-        $this->dispatch($instance = new Container\Events\AfterResolution(
-            $this->entries[$id],
-            $id,
-        ));
-
-        $entry = $instance->getEntry();
+        $entry = $this->entries[$id];
 
         if (\is_object($entry) && ! \is_callable($entry)) {
-            return $entry;
+            $resolved = $entry;
+        } else {
+            /** @var array{object|string,string}|callable|object|string $entry */
+            $resolved = $this->resolver->handle($entry);
         }
 
-        /** @var array{object|string,string}|callable|object|string $entry */
-        return $this->handledEntries[$id] = $this->resolver->handle($entry);
+        if (\is_object($resolved) || \is_callable($resolved)) {
+            $this->dispatch($after = new Container\Events\AfterResolution($resolved, $id));
+            $resolved = $after->getEntry();
+        }
+
+        return $this->handledEntries[$id] = $resolved;
     }
 
     /**
@@ -193,10 +195,12 @@ class Container implements ContainerInterface
             unset($this->handledEntries[$id]);
         }
 
-        $this->dispatch(new Container\Events\AfterRegistration(
+        $this->dispatch($after = new Container\Events\AfterRegistration(
             $this->entries[$id],
             $id,
         ));
+
+        $this->entries[$id] = $after->getEntry();
 
         return $this;
     }
@@ -247,6 +251,14 @@ class Container implements ContainerInterface
             ));
         }
 
+        $id = \is_string($instance) ? $instance : null;
+
+        if ($id) {
+            $this->dispatch($pre = new Container\Events\BeforeResolution($id));
+            $instance = $pre->id;
+            $id = $instance;
+        }
+
         $instance = $this->resolver->resolve(
             \is_string($instance) && isset($this->factories[$instance])
                 ? $this->factories[$instance]
@@ -258,7 +270,14 @@ class Container implements ContainerInterface
             $instance = $condition($instance) ?: $instance;
         }
 
-        return $this->resolver->handle($instance, $args);
+        $resolved = $this->resolver->handle($instance, $args);
+
+        if ($id && (\is_object($resolved) || \is_callable($resolved))) {
+            $this->dispatch($after = new Container\Events\AfterResolution($resolved, $id));
+            $resolved = $after->getEntry();
+        }
+
+        return $resolved;
     }
 
     /**

--- a/src/Container.php
+++ b/src/Container.php
@@ -30,7 +30,7 @@ class Container implements ContainerInterface
     private $factories = [];
 
     /**
-     * @var array<string, mixed> Cache of resolved singleton instances.
+     * @var array<string|class-string<object>, mixed|object> Cache of resolved singleton instances.
      */
     private $handledEntries = [];
 
@@ -120,6 +120,7 @@ class Container implements ContainerInterface
             );
         }
 
+        /** @var EventDispatcherInterface $dispatcher */
         $dispatcher = $this->entries->offsetGet(EventDispatcherInterface::class);
 
         return $this->handledEntries[EventDispatcherInterface::class] = $dispatcher;

--- a/src/Container.php
+++ b/src/Container.php
@@ -7,6 +7,7 @@ namespace Projek;
 use Closure;
 use Psr\Container\ContainerInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\EventDispatcher\ListenerProviderInterface;
 
 /**
  * PSR-11 Dependency Injection Container implementation.
@@ -46,7 +47,7 @@ class Container implements ContainerInterface
      */
     public function __construct(
         array $entries = [],
-        private ?EventDispatcherInterface $eventDispatcher = null,
+        ?EventDispatcherInterface $eventDispatcher = null,
     ) {
         $this->resolver = new Container\Resolver($this);
 
@@ -79,17 +80,49 @@ class Container implements ContainerInterface
     }
 
     /**
-     * Dispatch a container lifecycle event.
+     * Retrieve a PSR-14 event dispatcher instance.
      *
-     * This internal method handles the communication with the PSR-14
-     * event dispatcher if one is provided.
+     * If no implementation is provided by the developer, a minimalist
+     * internal implementation is returned to keep core hooks functional.
      *
-     * @param object $event The event object to dispatch.
-     * @return void
+     * @return EventDispatcherInterface
      */
-    private function dispatch(object $event): void
+    final public function getEventDispatcher(): EventDispatcherInterface
     {
-        $this->eventDispatcher?->dispatch($event);
+        if (isset($this->handledEntries[EventDispatcherInterface::class])) {
+            return $this->handledEntries[EventDispatcherInterface::class];
+        }
+
+        if (! $this->entries->offsetExists(EventDispatcherInterface::class)) {
+            // Simplest implementation to keep core hooks (like ContainerAware) working.
+            $this->entries->offsetSet(
+                EventDispatcherInterface::class,
+                new class ($this) implements EventDispatcherInterface {
+                    private ListenerProviderInterface $provider;
+
+                    public function __construct(ContainerInterface $container)
+                    {
+                        $this->provider = (new Container\Events\ListenerProvider())->setContainer($container);
+                    }
+
+                    public function dispatch(object $event): object
+                    {
+                        /** @var callable[] $listeners */
+                        $listeners = $this->provider->getListenersForEvent($event);
+
+                        foreach ($listeners as $listener) {
+                            $listener($event);
+                        }
+
+                        return $event;
+                    }
+                },
+            );
+        }
+
+        $dispatcher = $this->entries->offsetGet(EventDispatcherInterface::class);
+
+        return $this->handledEntries[EventDispatcherInterface::class] = $dispatcher;
     }
 
     /**
@@ -103,9 +136,10 @@ class Container implements ContainerInterface
      * @param EventDispatcherInterface $eventDispatcher The event dispatcher instance.
      * @return self
      */
-    public function setEventDispatcher(EventDispatcherInterface $eventDispatcher): self
+    final public function setEventDispatcher(EventDispatcherInterface $eventDispatcher): self
     {
-        $this->eventDispatcher = $eventDispatcher;
+        $this->entries->offsetSet(EventDispatcherInterface::class, $eventDispatcher);
+        $this->handledEntries[EventDispatcherInterface::class] = $eventDispatcher;
 
         return $this;
     }
@@ -121,7 +155,9 @@ class Container implements ContainerInterface
      */
     public function get(string $id)
     {
-        $this->dispatch($pre = new Container\Events\BeforeResolution($id));
+        $this->getEventDispatcher()->dispatch(
+            $pre = new Container\Events\BeforeResolution($id)
+        );
 
         // Allows service redirection via event.
         $id = $pre->id;
@@ -133,7 +169,10 @@ class Container implements ContainerInterface
         $resolved = $this->resolver->handle($this->entries[$id]);
 
         if (\is_object($resolved) || \is_callable($resolved)) {
-            $this->dispatch($after = new Container\Events\AfterResolution($resolved, $id));
+            $this->getEventDispatcher()->dispatch(
+                $after = new Container\Events\AfterResolution($resolved, $id)
+            );
+
             $resolved = $after->getEntry();
         }
 
@@ -177,10 +216,9 @@ class Container implements ContainerInterface
             ? \get_class($factory)
             : $factory;
 
-        $this->dispatch($registration = new Container\Events\BeforeRegistration(
-            $this->factories[$id],
-            $id,
-        ));
+        $this->getEventDispatcher()->dispatch(
+            $registration = new Container\Events\BeforeRegistration($this->factories[$id], $id)
+        );
 
         $this->entries[$id] = $this->resolver->resolve($registration->getFactory());
 
@@ -188,10 +226,9 @@ class Container implements ContainerInterface
             unset($this->handledEntries[$id]);
         }
 
-        $this->dispatch($registered = new Container\Events\AfterRegistration(
-            $this->entries[$id],
-            $id,
-        ));
+        $this->getEventDispatcher()->dispatch(
+            $registered = new Container\Events\AfterRegistration($this->entries[$id], $id)
+        );
 
         $this->entries[$id] = $registered->getEntry();
 
@@ -247,7 +284,10 @@ class Container implements ContainerInterface
         $id = \is_string($instance) ? $instance : null;
 
         if ($id) {
-            $this->dispatch($pre = new Container\Events\BeforeResolution($id));
+            $this->getEventDispatcher()->dispatch(
+                $pre = new Container\Events\BeforeResolution($id)
+            );
+
             $instance = $pre->id;
             $id = $instance;
         }
@@ -266,7 +306,10 @@ class Container implements ContainerInterface
         $resolved = $this->resolver->handle($instance, $args);
 
         if ($id && (\is_object($resolved) || \is_callable($resolved))) {
-            $this->dispatch($after = new Container\Events\AfterResolution($resolved, $id));
+            $this->getEventDispatcher()->dispatch(
+                $after = new Container\Events\AfterResolution($resolved, $id)
+            );
+
             $resolved = $after->getEntry();
         }
 

--- a/src/Container/Events/AfterRegistration.php
+++ b/src/Container/Events/AfterRegistration.php
@@ -36,4 +36,14 @@ final class AfterRegistration
     {
         return $this->entry;
     }
+
+    /**
+     * Set a new entry.
+     *
+     * @param callable|object $entry The new entry.
+     */
+    public function setEntry(callable|object $entry): void
+    {
+        $this->entry = $entry;
+    }
 }

--- a/src/Container/Events/AfterResolution.php
+++ b/src/Container/Events/AfterResolution.php
@@ -36,4 +36,14 @@ final class AfterResolution
     {
         return $this->entry;
     }
+
+    /**
+     * Set a new entry.
+     *
+     * @param callable|object $entry The new entry.
+     */
+    public function setEntry(callable|object $entry): void
+    {
+        $this->entry = $entry;
+    }
 }

--- a/src/Container/Events/Dispatcher.php
+++ b/src/Container/Events/Dispatcher.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Projek\Container\Events;
+
+use Psr\Container\ContainerInterface;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\EventDispatcher\ListenerProviderInterface;
+use Psr\EventDispatcher\StoppableEventInterface;
+
+/**
+ * Internal minimalist PSR-14 Event Dispatcher.
+ *
+ * @package Projek\Container
+ * @internal
+ */
+final class Dispatcher implements EventDispatcherInterface
+{
+    /**
+     * @var ListenerProviderInterface
+     */
+    private $provider;
+
+    /**
+     * @param ContainerInterface $container
+     * @param ListenerProviderInterface $provider
+     */
+    public function __construct(
+        ContainerInterface $container,
+        ?ListenerProviderInterface $provider = null
+    ) {
+        $this->provider = $provider ?? (new ListenerProvider())->setContainer($container);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function dispatch(object $event): object
+    {
+        foreach ($this->provider->getListenersForEvent($event) as $listener) {
+            if ($event instanceof StoppableEventInterface && $event->isPropagationStopped()) {
+                break;
+            }
+
+            $listener($event);
+        }
+
+        return $event;
+    }
+}

--- a/tests/spec/Container.spec.php
+++ b/tests/spec/Container.spec.php
@@ -572,4 +572,136 @@ describe(Container::class, function () {
             expect($newEntry->dummy)->not->toBe($this->c->get('dummy'));
         });
     });
+
+    context('Event Lifecycle', function () {
+        it('should dispatch AfterResolution with the resolved instance, not the factory', function () {
+            $factoryCalled = false;
+            $eventReceivedInstance = null;
+
+            $this->c->set('foo', function () use (&$factoryCalled) {
+                $factoryCalled = true;
+                return new stdClass();
+            });
+
+            $this->c->setEventDispatcher(new class ($this->provider, $eventReceivedInstance) extends TheDispatcher {
+                public function __construct(
+                    ListenerProviderInterface $provider,
+                    private &$eventReceivedInstance
+                ) {
+                    parent::__construct($provider);
+                }
+
+                public function dispatch(object $event): object
+                {
+                    if ($event instanceof Events\AfterResolution && $event->id === 'foo') {
+                        $this->eventReceivedInstance = $event->getEntry();
+                    }
+
+                    return parent::dispatch($event);
+                }
+            });
+
+            $instance = $this->c->get('foo');
+
+            expect($factoryCalled)->toBe(true);
+            expect($eventReceivedInstance)->toBe($instance);
+            expect($eventReceivedInstance)->toBeAnInstanceOf(stdClass::class);
+        });
+
+        it('should allow AfterResolution to wrap the instance (Decorator Pattern)', function () {
+            $this->c->set('service', function () {
+                return new class {
+                    public function work()
+                    {
+                        return 'working';
+                    }
+                };
+            });
+
+            // A simple decorator/proxy listener
+            $this->c->setEventDispatcher(new class ($this->provider) extends TheDispatcher {
+                public function dispatch(object $event): object
+                {
+                    if ($event instanceof Events\AfterResolution && $event->id === 'service') {
+                        $original = $event->getEntry();
+                        // Wrap the original service in a proxy
+                        $proxy = new class ($original) {
+                            public function __construct(private $original)
+                            {
+                            }
+                            public function work()
+                            {
+                                return 'proxying ' . $this->original->work();
+                            }
+                        };
+                        $event->setEntry($proxy);
+                    }
+
+                    return parent::dispatch($event);
+                }
+            });
+
+            $instance = $this->c->get('service');
+
+            expect($instance->work())->toBe('proxying working');
+        });
+
+        it('should allow AfterRegistration to modify the registered entry', function () {
+            // A listener that eagerly initializes or modifies a service right after registration
+            $this->c->setEventDispatcher(new class ($this->provider) extends TheDispatcher {
+                public function dispatch(object $event): object
+                {
+                    if ($event instanceof Events\AfterRegistration && $event->id === 'modified.service') {
+                        $entry = $event->getEntry();
+                        if ($entry instanceof stdClass) {
+                            $entry->modified = true;
+                        }
+                        // Explicitly set the modified entry back
+                        $event->setEntry($entry);
+                    }
+
+                    return parent::dispatch($event);
+                }
+            });
+
+            $this->c->set('modified.service', new stdClass());
+
+            $instance = $this->c->get('modified.service');
+            expect($instance->modified)->toBe(true);
+        });
+
+        it('should dispatch BeforeResolution and AfterResolution events in make()', function () {
+            $beforeCalled = false;
+            $afterCalled = false;
+
+            $this->c->setEventDispatcher(new class ($this->provider, $beforeCalled, $afterCalled) extends TheDispatcher {
+                private $beforeCalled;
+                private $afterCalled;
+                public function __construct($provider, &$beforeCalled, &$afterCalled)
+                {
+                    parent::__construct($provider);
+                    $this->beforeCalled = &$beforeCalled;
+                    $this->afterCalled = &$afterCalled;
+                }
+
+                public function dispatch(object $event): object
+                {
+                    if ($event instanceof Events\BeforeResolution && $event->id === stdClass::class) {
+                        $this->beforeCalled = true;
+                    }
+                    if ($event instanceof Events\AfterResolution && $event->id === stdClass::class) {
+                        $this->afterCalled = true;
+                    }
+
+                    return parent::dispatch($event);
+                }
+            });
+
+            $instance = $this->c->make(stdClass::class);
+
+            expect($instance)->toBeAnInstanceOf(stdClass::class);
+            expect($beforeCalled)->toBe(true);
+            expect($afterCalled)->toBe(true);
+        });
+    });
 });

--- a/tests/spec/Container.spec.php
+++ b/tests/spec/Container.spec.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Projek\Container;
 use Projek\Container\Events;
 use Psr\Container\ContainerInterface;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\EventDispatcher\ListenerProviderInterface;
 use Stubs\HasContainerClass;
 use Stubs\TheDispatcher;
@@ -574,6 +575,18 @@ describe(Container::class, function () {
     });
 
     context('Event Lifecycle', function () {
+        it('should use anonymous EventDispatcher when none provided', function () {
+            // A "pure" container with no dispatcher provided to constructor
+            $pure = new Container();
+            $pure->set(HasContainerClass::class, HasContainerClass::class);
+
+            $instance = $pure->get(HasContainerClass::class);
+
+            // ContainerAware should still work via the anonymous dispatcher
+            expect($instance->getContainer())->toBe($pure);
+            expect($pure->getEventDispatcher())->toBeAnInstanceOf(EventDispatcherInterface::class);
+        });
+
         it('should dispatch AfterResolution with the resolved instance, not the factory', function () {
             $factoryCalled = false;
             $eventReceivedInstance = null;

--- a/tests/spec/Container.spec.php
+++ b/tests/spec/Container.spec.php
@@ -2,19 +2,21 @@
 
 declare(strict_types=1);
 
+use Kahlan\Plugin\Double;
 use Projek\Container;
 use Projek\Container\Events;
 use Psr\Container\ContainerInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\EventDispatcher\ListenerProviderInterface;
+use Psr\EventDispatcher\StoppableEventInterface;
 use Stubs\HasContainerClass;
 use Stubs\TheDispatcher;
 
 describe(Container::class, function () {
     beforeEach(function () {
+        $this->c = new Container([]);
+
         $this->provider = new Events\ListenerProvider();
-        $this->dispatcher = new TheDispatcher($this->provider);
-        $this->c = new Container([], $this->dispatcher);
         $this->provider->setContainer($this->c);
     });
 
@@ -315,11 +317,11 @@ describe(Container::class, function () {
             $this->c->set('foo', function () {
                 return new class {
                     protected $items = [];
-                    public function set($item, $value)
+                    public function set(string $item, mixed $value)
                     {
                         $this->items[$item] = $value;
                     }
-                    public function get($item)
+                    public function get(string $item)
                     {
                         return $this->items[$item] ?? null;
                     }
@@ -577,14 +579,48 @@ describe(Container::class, function () {
     context('Event Lifecycle', function () {
         it('should use anonymous EventDispatcher when none provided', function () {
             // A "pure" container with no dispatcher provided to constructor
-            $pure = new Container();
-            $pure->set(HasContainerClass::class, HasContainerClass::class);
+            $this->c->set(HasContainerClass::class, HasContainerClass::class);
 
-            $instance = $pure->get(HasContainerClass::class);
+            $instance = $this->c->get(HasContainerClass::class);
 
             // ContainerAware should still work via the anonymous dispatcher
-            expect($instance->getContainer())->toBe($pure);
-            expect($pure->getEventDispatcher())->toBeAnInstanceOf(EventDispatcherInterface::class);
+            expect($instance->getContainer())->toBe($this->c);
+            expect($this->c->getEventDispatcher())->toBeAnInstanceOf(EventDispatcherInterface::class);
+        });
+
+        it('should respect stoppable events in anonymous EventDispatcher', function () {
+            // Test loop break (after listener) using a custom provider to ensure multiple listeners
+            $provider = new class implements ListenerProviderInterface {
+                public $count = 0;
+                public function getListenersForEvent(object $event): iterable
+                {
+                    return [
+                        function ($e) {
+                            $this->count++;
+                            $e->stop = true;
+                        },
+                        function ($e) {
+                            $this->count++;
+                        },
+                    ];
+                }
+            };
+
+            $this->c->setEventDispatcher(
+                new Events\Dispatcher($this->c, $provider)
+            );
+
+            $stoppable = new class () implements StoppableEventInterface {
+                public $stop = false;
+                public function isPropagationStopped(): bool
+                {
+                    return $this->stop;
+                }
+            };
+
+            $this->c->getEventDispatcher()->dispatch($stoppable);
+
+            expect($provider->count)->toBe(1); // Second listener should be skipped
         });
 
         it('should dispatch AfterResolution with the resolved instance, not the factory', function () {
@@ -639,7 +675,7 @@ describe(Container::class, function () {
                         $original = $event->getEntry();
                         // Wrap the original service in a proxy
                         $proxy = new class ($original) {
-                            public function __construct(private $original)
+                            public function __construct(private object $original)
                             {
                             }
                             public function work()
@@ -690,8 +726,12 @@ describe(Container::class, function () {
             $this->c->setEventDispatcher(new class ($this->provider, $beforeCalled, $afterCalled) extends TheDispatcher {
                 private $beforeCalled;
                 private $afterCalled;
-                public function __construct($provider, &$beforeCalled, &$afterCalled)
-                {
+
+                public function __construct(
+                    ListenerProviderInterface $provider,
+                    bool &$beforeCalled,
+                    bool &$afterCalled
+                ) {
                     parent::__construct($provider);
                     $this->beforeCalled = &$beforeCalled;
                     $this->afterCalled = &$afterCalled;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PSR-14 event lifecycle is now central to container operations: BeforeResolution/AfterResolution and BeforeRegistration/AfterRegistration run by default, with a built-in fallback dispatcher.
  * Listeners can modify or replace registered and resolved entries, enabling decorators, proxies, ID redirection, and eager initialization.

* **Tests**
  * Added event lifecycle tests covering dispatcher fallback, propagation control, entry mutation, and make()/get() dispatch behavior.

* **Documentation**
  * Updated docs and README to describe zero‑config container awareness and the PSR‑14 event lifecycle.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projek-xyz/container/pull/86?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->